### PR TITLE
Deleting profiles on HomeAdminFragment, and other changes

### DIFF
--- a/app/src/main/java/com/example/butter/ConfirmationDialog.java
+++ b/app/src/main/java/com/example/butter/ConfirmationDialog.java
@@ -25,7 +25,7 @@ public class ConfirmationDialog {
      * Confirmation Dialog constructor. Intializes the context, listener and deletedItem
      * @param context activity or fragment dialog is being displayed in
      * @param listener listener that allows dialog to communicate with the activity or fragment
-     * @param deletedItem is either Event, Facility, QR Code, or Event Poster
+     * @param deletedItem is either Event, Facility, User Profile, QR Code, or Event Poster
      */
     public ConfirmationDialog(Context context, ConfirmationDialogListener listener, String deletedItem) {
         this.context = context;

--- a/app/src/main/java/com/example/butter/CreateProfileActivity.java
+++ b/app/src/main/java/com/example/butter/CreateProfileActivity.java
@@ -121,36 +121,46 @@ public class CreateProfileActivity extends AppCompatActivity {
 
                     // now to set privilege values:
                     // Entrant = 100, Organizer = 200, both = 300
-                    if (role.equals("Entrant")) privileges = 100;
+                    if (role.equals("Entrant")) {privileges = 100; facility = null;}
                     if (role.equals("Organizer")) privileges = 200;
                     if (role.equals("Both")) privileges = 300;
 
                     // create the user obj
                     User user = new User(getIntent().getExtras().getString("deviceID"), username.trim(), privileges, facility, email, phone);
 
-                    // finally, lets check if this facility conflicts with another in the db.
-                    String finalFacility = facility;
-                    fetchFacilities(new OnFacilitiesLoadedCallback() {
-                        @Override
-                        public void checkForFacility(List<String> facilities) {
-                            // check if the facility is in our facility list fetch from db
-                            if (!facilities.contains(finalFacility)) { // if the facility is not in db
-                                // add the user to the db, and go to main
-                                users.add(user);
+                    if (facility != null) { // if we are an org
+                        // finally, lets check if this facility conflicts with another in the db.
+                        String finalFacility = facility;
+                        fetchFacilities(new OnFacilitiesLoadedCallback() {
+                            @Override
+                            public void checkForFacility(List<String> facilities) {
+                                // check if the facility is in our facility list fetch from db
+                                if (!facilities.contains(finalFacility)) { // if the facility is not in db
+                                    // add the user to the db, and go to main
+                                    users.add(user);
 
-                                // now our new user should be in the database, and go to MainActivity
-                                Intent toMainActivity = new Intent(CreateProfileActivity.this, MainActivity.class);
-                                startActivity(toMainActivity);
-                                finish();
-                            } else {    // else create builder and conflicting facility error
-                                AlertDialog.Builder builder = new AlertDialog.Builder(CreateProfileActivity.this);
-                                builder.setTitle("Invalid Signup");
-                                builder.setMessage("Conflicting Facility Name.\nPlease try again.");
-                                builder.setPositiveButton("OK", null);
-                                builder.show();
+                                    // now our new user should be in the database, and go to MainActivity
+                                    Intent toMainActivity = new Intent(CreateProfileActivity.this, MainActivity.class);
+                                    startActivity(toMainActivity);
+                                    finish();
+                                } else {    // else create builder and conflicting facility error
+                                    AlertDialog.Builder builder = new AlertDialog.Builder(CreateProfileActivity.this);
+                                    builder.setTitle("Invalid Signup");
+                                    builder.setMessage("Conflicting Facility Name.\nPlease try again.");
+                                    builder.setPositiveButton("OK", null);
+                                    builder.show();
+                                }
                             }
-                        }
-                    });
+                        });
+                    } else {    // else we are not an org, and should just add in db
+                        // add the user to the db, and go to main
+                        users.add(user);
+
+                        // now our new user should be in the database, and go to MainActivity
+                        Intent toMainActivity = new Intent(CreateProfileActivity.this, MainActivity.class);
+                        startActivity(toMainActivity);
+                        finish();
+                    }
                 } else {    // else then show dialogue message and continue
                     AlertDialog.Builder builder = new AlertDialog.Builder(CreateProfileActivity.this);
                     builder.setTitle("Invalid Signup");

--- a/app/src/main/java/com/example/butter/HomeAdminFragment.java
+++ b/app/src/main/java/com/example/butter/HomeAdminFragment.java
@@ -41,6 +41,7 @@ public class HomeAdminFragment extends Fragment implements ConfirmationDialog.Co
     private FirebaseFirestore db;
     private CollectionReference eventRef;
     private CollectionReference userRef;
+    private CollectionReference userListRef;
     private CollectionReference QRCodeRef;
     private CollectionReference imagesRef;
 
@@ -65,6 +66,7 @@ public class HomeAdminFragment extends Fragment implements ConfirmationDialog.Co
     User selectedOrganizer;
     String selectedQRCode;
     String selectedImage;
+    User selectedUser;
 
     /**
      * Constructor for HomeAdminFragment, initializes array lists and reference to database
@@ -83,6 +85,7 @@ public class HomeAdminFragment extends Fragment implements ConfirmationDialog.Co
         db = FirebaseFirestore.getInstance();
         eventRef = db.collection("event"); // event collection
         userRef = db.collection("user"); // user collection
+        userListRef = db.collection("userList");
         QRCodeRef = db.collection("QRCode");
         imagesRef = db.collection("image");
         this.browse = browse;
@@ -129,6 +132,7 @@ public class HomeAdminFragment extends Fragment implements ConfirmationDialog.Co
                 break;
             case "Browse Profiles":
                 adminListView.setAdapter(profileArrayAdapter);
+                deleteButton.setVisibility(VISIBLE);
                 break;
             case "Browse Images":
                 adminListView.setAdapter(imageArrayAdapter);
@@ -154,7 +158,7 @@ public class HomeAdminFragment extends Fragment implements ConfirmationDialog.Co
                     intent.putExtra("adminPrivilege", Boolean.TRUE); // User has admin priviliges, used in eventDetailsActivity for special priviliges
                     startActivity(intent);
                 } else if (browse.equals("Browse Profiles")) {
-
+                    selectedUser = allUsers.get(position);
                 } else if (browse.equals("Browse Facilities")) {
                     selectedOrganizer = allFacilities.get(position);
                 } else if (browse.equals("Browse QR Codes")) {
@@ -187,7 +191,9 @@ public class HomeAdminFragment extends Fragment implements ConfirmationDialog.Co
             imageArrayAdapter.notifyDataSetChanged();
             selectedImage = null;
 
-            Toast.makeText(getContext(), "The Image has been succesfully deleted.", Toast.LENGTH_SHORT).show();
+            Toast.makeText(getContext(), "Image successfully deleted.", Toast.LENGTH_SHORT).show();
+        } else {
+            Toast.makeText(getContext(), "No Image selected.", Toast.LENGTH_SHORT).show();
         }
     }
 
@@ -208,7 +214,105 @@ public class HomeAdminFragment extends Fragment implements ConfirmationDialog.Co
             QRCodeArrayAdapter.notifyDataSetChanged();
             selectedQRCode = null;
 
-            Toast.makeText(getContext(), "The QR code has been successfully deleted.", Toast.LENGTH_SHORT).show();
+            Toast.makeText(getContext(), "QR code successfully deleted.", Toast.LENGTH_SHORT).show();
+        } else {
+            Toast.makeText(getContext(), "No QR code selected.", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    /**
+     * Deletes Selected User Profile
+     * @author Soopyman
+     */
+    private void deleteSelectedUser() {
+        if (selectedUser != null) { // if we have a user
+            // first grab user id
+            String userID = selectedUser.getDeviceID();
+
+            // setup db objects
+            UserDB userDB = new UserDB();
+            EventDB eventDB = new EventDB();
+            UserListDB userListDB = new UserListDB();
+            ImageDB imageDB = new ImageDB();
+            NotificationDB notificationDB = new NotificationDB();
+            MapDB mapDB = new MapDB();
+            QRCodeDB qrcodeDB = new QRCodeDB();
+
+            // then lets remove all data associated with the user
+
+            // remove the user from all event lists
+            userListRef.get().addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
+                @Override
+                public void onComplete(@NonNull Task<QuerySnapshot> task) {
+                    if (task.isSuccessful()) {  // if we have a doc
+                        // lets loop over all the docs and call to delete in userListDB
+                        for (DocumentSnapshot doc : task.getResult()) {
+                            String listID = doc.getId();
+
+                            // delete user from list if exists
+                            userListDB.removeFromList(listID, userID);
+                        }
+                    } else {
+                        Log.d("Firebase", "Error getting documents: ", task.getException());
+                    }
+                }
+            });
+
+            // remove user pfp from imageDB
+            imageDB.delete(userID);
+            // delete notifications sent to user
+            notificationDB.deleteNotificationsToUser(userID);
+
+            // finally, lets check if they are an organizer. if so, delete all events associated with user
+            if (selectedUser.getPrivileges() != 100 && selectedUser.getPrivileges() != 400 && selectedUser.getPrivileges() != 500) { // if our user is an organizer
+                // if so, we are an organizer and may have existing events
+                // delete these events and all items associated with them
+
+                // first lets query for event, search for "eventInfo.organizerID"
+                eventRef.get().addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
+                    @Override
+                    public void onComplete(@NonNull Task<QuerySnapshot> task) {
+                        if (task.isSuccessful()) {  // if we found the ref
+                            // lets go over all events and search for one with corresponding org id
+                            for (DocumentSnapshot doc : task.getResult()) {
+                                String eventID = doc.getId();   // get event id
+                                String eventOID = doc.getString("eventInfo.organizerID"); // get org id
+                                if (userID.equals(eventOID)) {  // if our user is the same, delete this event and all associated data
+                                    // setup calls to various userLists
+                                    String waitListID = eventID + "-wait";
+                                    String drawListID = eventID + "-draw";
+                                    String registerListID = eventID + "-registered";
+                                    String cancelledListID = eventID + "-cancelled";
+
+                                    // delete from various user lists
+                                    userListDB.deleteList(waitListID);
+                                    userListDB.deleteList(drawListID);
+                                    userListDB.deleteList(registerListID);
+                                    userListDB.deleteList(cancelledListID);
+
+                                    // delete all other attributes associated with event
+                                    qrcodeDB.delete(eventID);
+                                    imageDB.delete(eventID);
+                                    mapDB.deleteMap(eventID);
+                                    notificationDB.deleteNotificationsFromEvent(eventID);
+
+                                    // finally, delete the event
+                                    eventDB.delete(eventID);
+                                }
+                            }
+                        } else {    // else we failed to get the doc
+                            Log.d("Firebase", "Error getting documents: ", task.getException());
+                        }
+                    }
+                });
+            }
+
+            // finally, we delete the user from the user database
+            userDB.delete(userID);
+
+            Toast.makeText(getContext(), "User Profile successfully deleted.", Toast.LENGTH_SHORT).show();
+        } else { // else, we do not currently have a user selected
+            Toast.makeText(getContext(), "No User Profile selected.", Toast.LENGTH_SHORT).show();
         }
     }
 
@@ -251,6 +355,8 @@ public class HomeAdminFragment extends Fragment implements ConfirmationDialog.Co
             selectedOrganizer = null;
 
             Toast.makeText(getContext(), deletedFacility + " deleted.", Toast.LENGTH_SHORT).show();
+        } else {
+            Toast.makeText(getContext(), "No Facility selected.", Toast.LENGTH_SHORT).show();
         }
     }
 
@@ -283,6 +389,9 @@ public class HomeAdminFragment extends Fragment implements ConfirmationDialog.Co
                     dialog.showDialog();
                 } else if (browse.equals("Browse Images")) {
                     ConfirmationDialog dialog = new ConfirmationDialog(getContext(), HomeAdminFragment.this, "Image");
+                    dialog.showDialog();
+                } else if (browse.equals("Browse Profiles")) {
+                    ConfirmationDialog dialog = new ConfirmationDialog(getContext(), HomeAdminFragment.this, "User Profile");
                     dialog.showDialog();
                 }
             }
@@ -351,7 +460,7 @@ public class HomeAdminFragment extends Fragment implements ConfirmationDialog.Co
      * Show Profiles List method: populates the admin list with all user profiles
      */
     public void showProfilesList() {
-        deleteButton.setVisibility(View.INVISIBLE);
+        deleteButton.setVisibility(VISIBLE);
         adminListView.setAdapter(profileArrayAdapter);
 
         userRef.get().addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
@@ -557,6 +666,9 @@ public class HomeAdminFragment extends Fragment implements ConfirmationDialog.Co
                     break;
                 case "Image":
                     deleteSelectedImage();
+                    break;
+                case "User Profile":
+                    deleteSelectedUser();
                     break;
             }
         } else {


### PR DESCRIPTION
Add the ability to delete profiles on the admin profiles page, ensuring that all associated data is deleted from the db.
Fixed a bug introduced in PR 100 which caused signup/editing a profile to check for conflicting facilities, even if we are not an org.
Also added Invalid toast messages to deleting items when no item is selected.
Implemented the deletion of events corresponding to a facility when that facility is deleted on the admin page.